### PR TITLE
라이브 입장 전 대기실 생성

### DIFF
--- a/src/main/java/com/webrtc/signalingserver/config/SessionConfig.java
+++ b/src/main/java/com/webrtc/signalingserver/config/SessionConfig.java
@@ -5,6 +5,7 @@ import com.webrtc.signalingserver.repository.MemoryRepository;
 import com.webrtc.signalingserver.repository.MemorySessionRepository;
 import com.webrtc.signalingserver.repository.ObjectRepository;
 import com.webrtc.signalingserver.repository.SessionRepository;
+import com.webrtc.signalingserver.service.TemplateForSynchronized;
 import com.webrtc.signalingserver.service.WebSocketService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +27,11 @@ public class SessionConfig {
 
     @Bean
     WebSocketService webSocketService() {
-        return new WebSocketService(objectRepository(), sessionRepository());
+        return new WebSocketService(objectRepository(), sessionRepository(), templateForSynchronized());
+    }
+
+    @Bean TemplateForSynchronized templateForSynchronized() {
+        return new TemplateForSynchronized();
     }
 
     @Bean

--- a/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
@@ -9,6 +9,9 @@ import java.util.List;
 import java.util.Map;
 
 public class MemorySessionRepository implements SessionRepository{
+    //lecture id, waiting session participants
+    private final Map<String, List<WebSocket>> waitingRoom = new HashMap<>();
+
     // member id, member socket
     private final Map<String, WebSocket> connections = new HashMap<>();
 
@@ -105,5 +108,15 @@ public class MemorySessionRepository implements SessionRepository{
     @Override
     public void addSessionOnLecture(String lectureId, String targetToAdd) {
         sessionManager.get(lectureId).add(targetToAdd);
+    }
+
+    @Override
+    public Boolean containsKeyOnWaitingRoom(String key) {
+        return waitingRoom.containsKey(key);
+    }
+
+    @Override
+    public void addConnectionOnWaitingRoom(String key, WebSocket connection) {
+        waitingRoom.get(key).add(connection);
     }
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
@@ -3,23 +3,23 @@ package com.webrtc.signalingserver.repository;
 import org.java_websocket.WebSocket;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class MemorySessionRepository implements SessionRepository{
     //lecture id, waiting session participants
-    private final Map<String, List<WebSocket>> waitingRoom = new HashMap<>();
+    private final ConcurrentMap<String, List<WebSocket>> waitingRoom = new ConcurrentHashMap<>();
 
     // member id, member socket
-    private final Map<String, WebSocket> connections = new HashMap<>();
+    private final ConcurrentMap<String, WebSocket> connections = new ConcurrentHashMap<>();
 
     // lecture id, session participants
-    private final Map<String, List<String>> sessionManager = new HashMap<>();
+    private final ConcurrentMap<String, List<String>> sessionManager = new ConcurrentHashMap<>();
 
     // member id, message
-    private final Map<String, String> messageOffer = new HashMap<>();
+    private final ConcurrentMap<String, String> messageOffer = new ConcurrentHashMap<>();
 
     @Override
     public Boolean containsKeyOnConnections(String key) {
@@ -121,7 +121,7 @@ public class MemorySessionRepository implements SessionRepository{
     }
 
     @Override
-    public List<WebSocket> getConnectionOnWaitingRoom(String key) {
+    public List<WebSocket> getConnectionsOnWaitingRoom(String key) {
         return waitingRoom.get(key);
     }
 

--- a/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
@@ -129,4 +129,9 @@ public class MemorySessionRepository implements SessionRepository{
     public void removeKeyOnWaitingRoom(String key) {
         waitingRoom.remove(key);
     }
+
+    @Override
+    public void createWaitingRoomByLectureId(String key) {
+        waitingRoom.put(key, new LinkedList<>());
+    }
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/MemorySessionRepository.java
@@ -119,4 +119,14 @@ public class MemorySessionRepository implements SessionRepository{
     public void addConnectionOnWaitingRoom(String key, WebSocket connection) {
         waitingRoom.get(key).add(connection);
     }
+
+    @Override
+    public List<WebSocket> getConnectionOnWaitingRoom(String key) {
+        return waitingRoom.get(key);
+    }
+
+    @Override
+    public void removeKeyOnWaitingRoom(String key) {
+        waitingRoom.remove(key);
+    }
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
@@ -31,7 +31,7 @@ public interface SessionRepository {
     // waitingRoom
     Boolean containsKeyOnWaitingRoom(String changeLongToString);
     void addConnectionOnWaitingRoom(String changeLongToString, WebSocket socket);
-    List<WebSocket> getConnectionOnWaitingRoom(String changeLongToString);
+    List<WebSocket> getConnectionsOnWaitingRoom(String changeLongToString);
     void removeKeyOnWaitingRoom(String changeLongToString);
     void createWaitingRoomByLectureId(String changeLongToString);
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
@@ -33,4 +33,5 @@ public interface SessionRepository {
     void addConnectionOnWaitingRoom(String changeLongToString, WebSocket socket);
     List<WebSocket> getConnectionOnWaitingRoom(String changeLongToString);
     void removeKeyOnWaitingRoom(String changeLongToString);
+    void createWaitingRoomByLectureId(String changeLongToString);
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
@@ -31,4 +31,6 @@ public interface SessionRepository {
     // waitingRoom
     Boolean containsKeyOnWaitingRoom(String changeLongToString);
     void addConnectionOnWaitingRoom(String changeLongToString, WebSocket socket);
+    List<WebSocket> getConnectionOnWaitingRoom(String changeLongToString);
+    void removeKeyOnWaitingRoom(String changeLongToString);
 }

--- a/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
+++ b/src/main/java/com/webrtc/signalingserver/repository/SessionRepository.java
@@ -28,5 +28,7 @@ public interface SessionRepository {
     void removeSessionOnLecture(String lectureId, String targetToRemove);
     void addSessionOnLecture(String lectureId, String targetToAdd);
 
-
+    // waitingRoom
+    Boolean containsKeyOnWaitingRoom(String changeLongToString);
+    void addConnectionOnWaitingRoom(String changeLongToString, WebSocket socket);
 }

--- a/src/main/java/com/webrtc/signalingserver/service/NeedToSynchronized.java
+++ b/src/main/java/com/webrtc/signalingserver/service/NeedToSynchronized.java
@@ -1,0 +1,5 @@
+package com.webrtc.signalingserver.service;
+
+public interface NeedToSynchronized {
+    void execute();
+}

--- a/src/main/java/com/webrtc/signalingserver/service/TemplateForSynchronized.java
+++ b/src/main/java/com/webrtc/signalingserver/service/TemplateForSynchronized.java
@@ -1,0 +1,11 @@
+package com.webrtc.signalingserver.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateForSynchronized {
+
+    public synchronized void executeToSynchronize(NeedToSynchronized method) {
+        method.execute();
+    }
+}

--- a/src/main/java/com/webrtc/signalingserver/service/TemplateForSynchronized.java
+++ b/src/main/java/com/webrtc/signalingserver/service/TemplateForSynchronized.java
@@ -2,7 +2,6 @@ package com.webrtc.signalingserver.service;
 
 import org.springframework.stereotype.Component;
 
-@Component
 public class TemplateForSynchronized {
 
     public synchronized void executeToSynchronize(NeedToSynchronized method) {

--- a/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
+++ b/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
@@ -47,7 +47,7 @@ public class WebSocketService {
         NeedToSynchronized executingLogic = () -> {
             // SessionManager에 해당 강의 Id가 키로 있는지 조사(요청 시점에 강의가 생성되었을 수도 있으니)
             Boolean lectureProceeding = sessionRepository.containsLectureSessionOnSessionManager(changeLongToString(lecture.getId()));
-
+            log.info("proceeding: {}",lectureProceeding);
             // 있는 경우, 이미 강의 라이브 진행중 (요청 시점에 라이브 실행됨)
             // 컬렉션에 커넥션 추가할 필요없이 강의가 생성되었음을 알림
             if (lectureProceeding){
@@ -89,7 +89,7 @@ public class WebSocketService {
 
             // 대기실에 있는 모든 클라이언트에게 강의 생성 알림
             if(sessionRepository.containsKeyOnWaitingRoom(changeLongToString(messageObj.lectureId))) {
-                List<WebSocket> connections = sessionRepository.getConnectionOnWaitingRoom(changeLongToString(messageObj.lectureId));
+                List<WebSocket> connections = sessionRepository.getConnectionsOnWaitingRoom(changeLongToString(messageObj.lectureId));
                 for (WebSocket connection : connections) {
                     Map<String, Object> map = GsonUtil.makeCommonMap("liveStarted", 0L, 200);
                     map.put("lecturerId", messageObj.userId);

--- a/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
+++ b/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
@@ -25,6 +25,13 @@ public class WebSocketService {
         this.sessionRepository = sessionRepository;
     }
 
+    public void isLiveProceeding(WebSocket socket, LiveRequestDto messageObj) {
+        boolean proceeding = sessionRepository.containsLectureSessionOnSessionManager(changeLongToString(messageObj.lectureId));
+        GsonUtil.sendLiveStatusMessage(socket, "isLiveProceeding", messageObj.userId, 200, proceeding);
+
+        log.info("라이브 진행 여부 발송 성공 proceeding: {}",proceeding);
+    }
+
     public void startLive(WebSocket socket, LiveRequestDto messageObj) {
         Lecture lecture = objectRepository.findLecture(messageObj.lectureId);
         ValidatePermission.validateLecturer(messageObj.userId, lecture);

--- a/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
+++ b/src/main/java/com/webrtc/signalingserver/service/WebSocketService.java
@@ -27,7 +27,10 @@ public class WebSocketService {
 
     public void isLiveProceeding(WebSocket socket, LiveRequestDto messageObj) {
         boolean proceeding = sessionRepository.containsLectureSessionOnSessionManager(changeLongToString(messageObj.lectureId));
-        GsonUtil.sendLiveStatusMessage(socket, "isLiveProceeding", messageObj.userId, 200, proceeding);
+
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("isLiveProceeding", messageObj.userId, 200);
+        objectMap.put("proceeding", proceeding);
+        GsonUtil.commonSendMessage(socket, objectMap);
 
         log.info("라이브 진행 여부 발송 성공 proceeding: {}",proceeding);
     }
@@ -67,8 +70,9 @@ public class WebSocketService {
         ValidatePermission.validateLecturer(messageObj.userId, lecture);
         startLiveLecture(messageObj.lectureId, messageObj.userId, socket);
 
-        GsonUtil.commonSendMessage(socket, "startLive", messageObj.userId,
-                200);
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("startLive", messageObj.userId, 200);
+        GsonUtil.commonSendMessage(socket, objectMap);
+
 
         log.info("라이브 생성 성공, {}", socket.getRemoteSocketAddress());
     }
@@ -80,8 +84,8 @@ public class WebSocketService {
         ValidatePermission.validateAccessPermission(member, lectureToEnter);
         enterLiveLecture(messageObj.lectureId, messageObj.userId, socket);
 
-        GsonUtil.commonSendMessage(socket, "enterLive", messageObj.userId,
-                200);
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("enterLive", messageObj.userId, 200);
+        GsonUtil.commonSendMessage(socket, objectMap);
 
         log.info("라이브 입장 성공, {}", socket.getRemoteSocketAddress());
         sendToAll(messageObj.lectureId, messageObj.userId, String.format("%s님이 입장하셨습니다.", member.getName()));
@@ -119,9 +123,9 @@ public class WebSocketService {
                 socket.send(sessionRepository.getMessageOnMessageOffer(target));
             }
         }
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("sdp", messageObj.userId, 200);
+        GsonUtil.commonSendMessage(socket, objectMap);
 
-        GsonUtil.commonSendMessage(socket, "sdp", messageObj.userId,
-                200);
     }
 
     public void answer(WebSocket socket, LiveRequestDto messageObj, String message) {
@@ -135,9 +139,9 @@ public class WebSocketService {
         else {
             sendToAll(messageObj.lectureId, messageObj.userId, message);
         }
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("sdp", messageObj.userId, 200);
+        GsonUtil.commonSendMessage(socket, objectMap);
 
-        GsonUtil.commonSendMessage(socket, "sdp",messageObj.userId,
-                200);
     }
 
     public void exitLive(WebSocket socket, LiveRequestDto messageObj) {
@@ -169,9 +173,9 @@ public class WebSocketService {
         }
         log.info("client exited: {}", messageObj.userId);
 
+        Map<String, Object> objectMap = GsonUtil.makeCommonMap("exitLive", messageObj.userId, 200);
+        GsonUtil.commonSendMessage(socket, objectMap);
 
-        GsonUtil.commonSendMessage(socket, "exitLive", messageObj.userId,
-                200);
     }
 
 

--- a/src/main/java/com/webrtc/signalingserver/util/GsonUtil.java
+++ b/src/main/java/com/webrtc/signalingserver/util/GsonUtil.java
@@ -5,6 +5,9 @@ import com.google.gson.JsonObject;
 import org.java_websocket.WebSocket;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class GsonUtil{
 
     private static final Gson gson = new Gson();
@@ -19,32 +22,30 @@ public class GsonUtil{
         return gson.toJson(request);
     }
 
-    private static JsonObject makeJson(String type, Long userId, int status) {
+    private static JsonObject makeJson(Map<String, Object> format) {
         JsonObject jsonobject = new JsonObject();
-        jsonobject.addProperty("type", type);
-        jsonobject.addProperty("status", status);
-        jsonobject.addProperty("requester", userId);
-
+        for (String key : format.keySet()) {
+            if(format.get(key) instanceof String) jsonobject.addProperty(key, (String)format.get(key));
+            if(format.get(key) instanceof Number) jsonobject.addProperty(key, (Number)format.get(key));
+        }
         return jsonobject;
     }
 
-    public static void commonSendMessage(WebSocket socket, String type, Long userId, int status) {
-        JsonObject obj = makeJson(type, userId, status);
+    public static Map<String, Object> makeCommonMap(String type, Long userId, int status) {
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("type", type);
+        map.put("userId", userId);
+        map.put("status", status);
+
+        return map;
+    }
+
+    public static void commonSendMessage(WebSocket socket, Map<String, Object> keyValue) {
+        JsonObject obj = makeJson(keyValue);
 
         try {
             socket.send(encode(obj));
-        } catch (WebsocketNotConnectedException e) {
-            System.out.println("e = " + e);
-        }
-    }
-
-    public static void sendLiveStatusMessage(WebSocket socket, String type, Long userId,
-                                              int status, boolean proceeding){
-        JsonObject obj = makeJson(type, userId, status);
-        obj.addProperty("proceeding", proceeding);
-
-        try {
-            socket.send(GsonUtil.encode(obj));
         } catch (WebsocketNotConnectedException e) {
             System.out.println("e = " + e);
         }

--- a/src/main/java/com/webrtc/signalingserver/util/GsonUtil.java
+++ b/src/main/java/com/webrtc/signalingserver/util/GsonUtil.java
@@ -19,15 +19,32 @@ public class GsonUtil{
         return gson.toJson(request);
     }
 
-    public static void commonSendMessage(WebSocket socket, String type, Long userId, int status) {
-
+    private static JsonObject makeJson(String type, Long userId, int status) {
         JsonObject jsonobject = new JsonObject();
         jsonobject.addProperty("type", type);
         jsonobject.addProperty("status", status);
         jsonobject.addProperty("requester", userId);
 
+        return jsonobject;
+    }
+
+    public static void commonSendMessage(WebSocket socket, String type, Long userId, int status) {
+        JsonObject obj = makeJson(type, userId, status);
+
         try {
-            socket.send(GsonUtil.encode(jsonobject));
+            socket.send(encode(obj));
+        } catch (WebsocketNotConnectedException e) {
+            System.out.println("e = " + e);
+        }
+    }
+
+    public static void sendLiveStatusMessage(WebSocket socket, String type, Long userId,
+                                              int status, boolean proceeding){
+        JsonObject obj = makeJson(type, userId, status);
+        obj.addProperty("proceeding", proceeding);
+
+        try {
+            socket.send(GsonUtil.encode(obj));
         } catch (WebsocketNotConnectedException e) {
             System.out.println("e = " + e);
         }

--- a/src/test/java/com/webrtc/signalingserver/service/EnterLiveTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/EnterLiveTest.java
@@ -26,6 +26,7 @@ public class EnterLiveTest {
     ObjectRepository objectRepository;
     SessionRepository sessionRepository;
     WebSocketService webSocketService;
+    TemplateForSynchronized template;
 
     Member teacher;
     Member student1;
@@ -38,7 +39,8 @@ public class EnterLiveTest {
     public void setUp() {
         objectRepository = new MemoryRepository();
         sessionRepository = new MemorySessionRepository();
-        webSocketService = new WebSocketService(objectRepository, sessionRepository);
+        template = new TemplateForSynchronized();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository, template);
 
         teacher = new Member(1L, "teacher", MemberRole.LECTURER);
         student1 = new Member(2L, "student1", MemberRole.STUDENT);

--- a/src/test/java/com/webrtc/signalingserver/service/EnterWaitingRoomTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/EnterWaitingRoomTest.java
@@ -1,0 +1,167 @@
+package com.webrtc.signalingserver.service;
+
+import com.webrtc.signalingserver.TestWebSocketClient;
+import com.webrtc.signalingserver.domain.dto.LiveRequestDto;
+import com.webrtc.signalingserver.domain.entity.Lecture;
+import com.webrtc.signalingserver.domain.entity.Member;
+import com.webrtc.signalingserver.domain.entity.MemberRole;
+import com.webrtc.signalingserver.repository.MemoryRepository;
+import com.webrtc.signalingserver.repository.MemorySessionRepository;
+import com.webrtc.signalingserver.repository.ObjectRepository;
+import com.webrtc.signalingserver.repository.SessionRepository;
+import org.assertj.core.api.Assertions;
+import org.java_websocket.client.WebSocketClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Async;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.webrtc.signalingserver.util.EncryptString.changeLongToString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnterWaitingRoomTest {
+    WebSocketClient client;
+    WebSocketClient client1;
+    WebSocketClient teacherClient;
+    ObjectRepository objectRepository;
+    SessionRepository sessionRepository;
+    WebSocketService webSocketService;
+    TemplateForSynchronized template;
+
+    Member teacher;
+    Member student;
+    Member student1;
+    Lecture lecture;
+
+    @BeforeEach
+    public void setUp() {
+        objectRepository = new MemoryRepository();
+        sessionRepository = new MemorySessionRepository();
+        template = new TemplateForSynchronized();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository, template);
+
+        teacher = new Member(1L, "teacher", MemberRole.LECTURER);
+        student = new Member(2L, "student1", MemberRole.STUDENT);
+        student1 = new Member(3L, "student1", MemberRole.STUDENT);
+
+        lecture = new Lecture(1L, teacher);
+        lecture.getStudents().add(student);
+        lecture.getStudents().add(student1);
+
+        objectRepository.saveMember(teacher);
+        objectRepository.saveMember(student);
+        objectRepository.saveMember(student1);
+        objectRepository.saveLecture(lecture);
+
+    }
+
+    @Test
+    @DisplayName("대기실에 입장 시도(강의 생성 이전), 정상적으로 waiting room에 컨넥션 적재 성공")
+    public void enterWaitingRoomBeforeLiveStarted() throws Exception {
+        //Given
+        LiveRequestDto enterWaitingRoom = LiveRequestDto.buildBasicDto("enterWaitingRoom", student.getId(), lecture.getId(), null);
+        client = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+
+        LiveRequestDto enterWaitingRoom1 = LiveRequestDto.buildBasicDto("enterWaitingRoom", student1.getId(), lecture.getId(), null);
+        client1 = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+
+        //When
+        webSocketService.enterWaitingRoom(client.getConnection(), enterWaitingRoom);
+
+        //Then
+        // 정상적으로 대기실이 생성되는지 확인
+        assertThat(sessionRepository.containsKeyOnWaitingRoom(changeLongToString(lecture.getId()))).isTrue();
+        // 클라이언트가 정상적으로 담기는지 확인
+        assertThat(sessionRepository.getConnectionsOnWaitingRoom(changeLongToString(lecture.getId())).size()).isEqualTo(1);
+
+        //When
+        webSocketService.enterWaitingRoom(client1.getConnection(), enterWaitingRoom1);
+
+        //Then
+        // 두번쨰 대기실 입장 요청시 클라이언트가 정상적으로 담기는지 확인
+        assertThat(sessionRepository.getConnectionsOnWaitingRoom(changeLongToString(lecture.getId())).size()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("대기실 입장 시도(강의 생성 이후) 대기실 입장 거부, 생성 X")
+    public void enterWaitingRoomAfterLiveStarted() throws Exception {
+
+        //Given
+        // start live
+        teacherClient = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        LiveRequestDto startLive = LiveRequestDto.buildBasicDto("startLive", teacher.getId(), lecture.getId(), null);
+        webSocketService.startLive(teacherClient.getConnection(), startLive);
+
+        // 강의 생성 대기실 접속 요청
+        LiveRequestDto enterWaitingRoom = LiveRequestDto.buildBasicDto("enterWaitingRoom", student.getId(), lecture.getId(), null);
+        client = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+
+        //When
+        webSocketService.enterWaitingRoom(client.getConnection(), enterWaitingRoom);
+
+        //Then
+        // 정상적으로 대기실이 생성이 거부되었는지 확인
+        assertThat(sessionRepository.containsKeyOnWaitingRoom(changeLongToString(lecture.getId()))).isFalse();
+
+    }
+
+    // 대기실 입장, 라이브 시작 간 동기화 실현
+    @Test
+    @DisplayName("스레드를 이용한 동기화 처리 확인, 최종적으로 대기실이 비어있어야 함")
+    public void checkSynchronizedBetweenEnterWaitingRoomAndStartLive() throws Exception {
+        //When
+        int numberOfThreads = 6;
+        ExecutorService service = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        service.submit(() -> {
+            enterWaitingRoom(student.getId());
+            latch.countDown();
+        });
+        service.submit(() -> {
+            enterWaitingRoom(student.getId());
+            latch.countDown();
+        });
+        service.submit(() -> {
+            enterWaitingRoom(student.getId());
+            latch.countDown();
+        });
+        service.submit(() -> {
+            enterWaitingRoom(student.getId());
+            latch.countDown();
+        });
+        service.submit(() -> {
+            enterWaitingRoom(student.getId());
+            latch.countDown();
+        });
+        service.submit(() -> {
+            createLectureLive();
+            latch.countDown();
+        });
+
+        latch.await();
+
+        //Then
+        assertThat(sessionRepository.containsKeyOnWaitingRoom(changeLongToString(lecture.getId()))).isFalse();
+
+    }
+
+    void createLectureLive() {
+        teacherClient = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        LiveRequestDto startLive = LiveRequestDto.buildBasicDto("startLive", teacher.getId(), lecture.getId(), null);
+        webSocketService.startLive(teacherClient.getConnection(), startLive);
+    }
+
+    void enterWaitingRoom(Long studentId) {
+        LiveRequestDto enterWaitingRoom = LiveRequestDto.buildBasicDto("enterWaitingRoom", studentId, lecture.getId(), null);
+        client = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        webSocketService.enterWaitingRoom(client.getConnection(), enterWaitingRoom);
+    }
+
+}

--- a/src/test/java/com/webrtc/signalingserver/service/ExitLiveTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/ExitLiveTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExitLiveTest {
 
     WebSocketClient teacherClient;
-    WebSocketClient studentClient;
+    TemplateForSynchronized template;
     ObjectRepository objectRepository;
     SessionRepository sessionRepository;
     WebSocketService webSocketService;
@@ -40,7 +40,8 @@ public class ExitLiveTest {
     public void setUp() {
         objectRepository = new MemoryRepository();
         sessionRepository = new MemorySessionRepository();
-        webSocketService = new WebSocketService(objectRepository, sessionRepository);
+        template = new TemplateForSynchronized();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository, template);
 
         teacher1 = new Member(1L, "teacher", MemberRole.LECTURER);
         teacher2 = new Member(4L, "teacher1", MemberRole.LECTURER);

--- a/src/test/java/com/webrtc/signalingserver/service/IsLiveProceedingTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/IsLiveProceedingTest.java
@@ -1,0 +1,70 @@
+package com.webrtc.signalingserver.service;
+
+import com.webrtc.signalingserver.TestWebSocketClient;
+import com.webrtc.signalingserver.domain.dto.LiveRequestDto;
+import com.webrtc.signalingserver.domain.entity.Lecture;
+import com.webrtc.signalingserver.domain.entity.Member;
+import com.webrtc.signalingserver.domain.entity.MemberRole;
+import com.webrtc.signalingserver.repository.MemoryRepository;
+import com.webrtc.signalingserver.repository.MemorySessionRepository;
+import com.webrtc.signalingserver.repository.ObjectRepository;
+import com.webrtc.signalingserver.repository.SessionRepository;
+import org.java_websocket.client.WebSocketClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+class IsLiveProceedingTest {
+    WebSocketClient client;
+    ObjectRepository objectRepository;
+    SessionRepository sessionRepository;
+    WebSocketService webSocketService;
+
+    Member teacher;
+    Member student;
+    Lecture lecture;
+
+    @BeforeEach
+    public void setUp() {
+        objectRepository = new MemoryRepository();
+        sessionRepository = new MemorySessionRepository();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository);
+
+        teacher = new Member(1L, "teacher", MemberRole.LECTURER);
+        student = new Member(2L, "student1", MemberRole.STUDENT);
+
+        lecture = new Lecture(1L, teacher);
+        lecture.getStudents().add(student);
+
+        objectRepository.saveMember(teacher);
+        objectRepository.saveMember(student);
+        objectRepository.saveLecture(lecture);
+
+    }
+
+    @Test
+    @DisplayName("라이브 진행 중인 아닌경우, 라이브 진행 여부 요청시, false")
+    void isNotLiveProceeding() {
+        //  check isLiveProceeding
+        client = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        LiveRequestDto isLiveProceeding = LiveRequestDto.buildBasicDto("isLiveProceeding", student.getId(), lecture.getId(), null);
+        webSocketService.isLiveProceeding(client.getConnection(), isLiveProceeding);
+    }
+
+    @Test
+    @DisplayName("라이브 진행 중인 경우, 라이브 진행 여부 요청시, true")
+    void isLiveProceeding() {
+        //  check isLiveProceeding
+        // start live
+        WebSocketClient teacherClient = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        LiveRequestDto startLive = LiveRequestDto.buildBasicDto("startLive", teacher.getId(), lecture.getId(), null);
+        webSocketService.startLive(teacherClient.getConnection(), startLive);
+
+        //  check isLiveProceeding
+        client = new TestWebSocketClient(URI.create("ws://localhost:8888/"));
+        LiveRequestDto isLiveProceeding = LiveRequestDto.buildBasicDto("isLiveProceeding", student.getId(), lecture.getId(), null);
+        webSocketService.isLiveProceeding(client.getConnection(), isLiveProceeding);
+    }
+}

--- a/src/test/java/com/webrtc/signalingserver/service/IsLiveProceedingTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/IsLiveProceedingTest.java
@@ -21,6 +21,7 @@ class IsLiveProceedingTest {
     ObjectRepository objectRepository;
     SessionRepository sessionRepository;
     WebSocketService webSocketService;
+    TemplateForSynchronized template;
 
     Member teacher;
     Member student;
@@ -30,7 +31,8 @@ class IsLiveProceedingTest {
     public void setUp() {
         objectRepository = new MemoryRepository();
         sessionRepository = new MemorySessionRepository();
-        webSocketService = new WebSocketService(objectRepository, sessionRepository);
+        template = new TemplateForSynchronized();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository, template);
 
         teacher = new Member(1L, "teacher", MemberRole.LECTURER);
         student = new Member(2L, "student1", MemberRole.STUDENT);

--- a/src/test/java/com/webrtc/signalingserver/service/StartLiveTest.java
+++ b/src/test/java/com/webrtc/signalingserver/service/StartLiveTest.java
@@ -27,6 +27,7 @@ public class StartLiveTest {
     ObjectRepository objectRepository;
     SessionRepository sessionRepository;
     WebSocketService webSocketService;
+    TemplateForSynchronized template;
 
     Member teacher;
     Member teacher1;
@@ -41,7 +42,8 @@ public class StartLiveTest {
 
         objectRepository = new MemoryRepository();
         sessionRepository = new MemorySessionRepository();
-        webSocketService = new WebSocketService(objectRepository, sessionRepository);
+        template = new TemplateForSynchronized();
+        webSocketService = new WebSocketService(objectRepository, sessionRepository, template);
 
         teacher = new Member(1L, "teacher", MemberRole.LECTURER);
         teacher1 = new Member(4L, "teacher1", MemberRole.LECTURER);


### PR DESCRIPTION
## 대기실

### 문제

아직 라이브 강의가 개설되지 않은 상태에서 수강생이 라이브가 진행될 페이지에 접속해 잔류해 있는 상황을 고려한다.

### 해결 방법

라이브 강의가 시작되기 전에 수강생이 해당 페이지에 미리 접속해 있는 상황이라면,  이 수강생이 라이브 강의가 시작한 시점에 라이브 강의에 참여할 수 있는 2가지의 방법이 있다.

1. 적절한 시간 간격으로  해당 페이지 리로딩을 자동으로 반복해서 해준다. 
2. 해당 강의가 개설된 시점에 라이브 강의에 참여하지는 않았지만, 컨넥션을 유지하고 있는 클라이언트들에게 일괄적으로 라이브가 참여 가능한 상태임을 알리는 메세지를 보낸다. 이후에 참여를 할지 말지에 따른 의사결정을 클라이언트에게 위임한다.

### 구현 방향

1번의 경우, 브라우저에서 적절한 시간 간격으로 새로고침을 하도록 개발할 수 있으나, 리로딩하는 과정에서 서버측으로 계속 리소스 요청을 보내는 것이 낭비라는 판단하에 2번으로 구현하고자 `대기실` 이라는 개념을 만들었다.

대기실은 아직 강의 세션이 생성되지 않은 상황에서 이 때 접속한 클라이언트들의 컨넥션을 저장하는 공간이다. 후에 강의가 생성된 시점에 일괄적으로 현재 그 강의의 대기실의 있는 클라이언트들을 대상으로 강의가 열렸음을 알리기 위해 그 연결 상태들을 저장해 둔다. 뿐만 아니라 아직 강의가 개설되지 않은 경우, 수강생들만으로 따로 영상 채팅을 진행할 수 있게 개발을 진행할 수도 있으니 이러한 상황을 고려한 처사이다.

### 개발 방법

1. 강의가 열리기 전에 라이브 페이지에 접속한 클라이언트의 경우, 해당 클라이언트의 컨넥션을 강의 아이디를 키로 갖는 컬렉션에 저장해 둔다. 즉, 해당 컬렉션에 저장돼 있는 컨넥션에 경우 아직 강의가 열리기 전에 라이브 페이지에 접속한 클라이언트들을 의미한다. 
2. 컬렉션에 저장한 후, 클라이언트에게 아직 강의가 열리지 않았다는 응답 메세지를 보낸다.
3. 특정 강의가 열렸는데 해당 대기실 내에 강의 아이디를 키값으로 갖는 컬렉션이 존재한다면, 해당 컬렉션을 포함된 커넥션에게 강의가 열렸다는 응답을 보낸다.
4. 이후에 대기실에 강의 아이디 키값을 삭제한다. (이후에 클라이언트측에서 다시 enterLive 요청을 보내온다면 기존에 구현해 놨던 enterLive 로직이 정상적으로 작동될 것이다.) 키 값만 삭제하고, 이 컨넥션들을 서버 자체적으로 강의 세션에 추가시키지 않는 이유는 우선 해당 컨넥션이 아직 유효한 컨넥션인지 불분명하고, 기존에 만들어 놓은 로직을 재사용하기 위함이다.